### PR TITLE
feat: communicate payment status to the host page

### DIFF
--- a/packages/burner-plugin/src/ui/MoviePage.tsx
+++ b/packages/burner-plugin/src/ui/MoviePage.tsx
@@ -200,6 +200,10 @@ const MoviePage: React.FC<MoviePageContext> = ({ plugin, accounts, actions, asse
       ether: value,
     };
 
+    plugin.pluginContext.onSent(({ receipt }) => {
+      const payload = { status: receipt.status };
+      window.parent.postMessage({ whiterabbit: payload }, '*');
+    })
     actions.send(sendProps);
   };
 

--- a/packages/burner-plugin/src/ui/MoviePage.tsx
+++ b/packages/burner-plugin/src/ui/MoviePage.tsx
@@ -200,10 +200,12 @@ const MoviePage: React.FC<MoviePageContext> = ({ plugin, accounts, actions, asse
       ether: value,
     };
 
-    plugin.pluginContext.onSent(({ receipt }) => {
-      const payload = { status: receipt.status };
-      window.parent.postMessage({ whiterabbit: payload }, '*');
-    })
+    if (window.parent) {
+      plugin.pluginContext.onSent(({ receipt }) => {
+        const payload = { status: receipt.status };
+        window.parent.postMessage({ whiterabbit: payload }, '*');
+      });
+    }
     actions.send(sendProps);
   };
 

--- a/packages/burner-plugin/src/ui/MoviePage.tsx
+++ b/packages/burner-plugin/src/ui/MoviePage.tsx
@@ -203,6 +203,10 @@ const MoviePage: React.FC<MoviePageContext> = ({ plugin, accounts, actions, asse
     actions.send(sendProps);
   };
 
+  const decline = () => {
+    window.parent.postMessage({ whiterabbit: { status: false } }, '*');
+  }
+
   return (
     <Page className={classes.moviePage}>
       <ImageBackdrop backgroundImage={movieData.posterUrl}>
@@ -242,7 +246,11 @@ const MoviePage: React.FC<MoviePageContext> = ({ plugin, accounts, actions, asse
                     </PrimaryButton>
                     {exceedsBalance && <ButtonHint>Not enough money</ButtonHint>}
                   </div>
-                <ActionButton>Decline</ActionButton>
+                <ActionButton
+                  onClick={() => decline()}
+                >
+                  Decline
+                </ActionButton>
               </ActionButtons>
             );
           }}

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -32,11 +32,11 @@ Arguments:
 
 `requestPayment(tokenId)`
 \
-Request a payment for the movie referenced by given WhiteRabbit token (TBD).
+Request a payment for the movie referenced by given WhiteRabbit token (TBD). Returns a Promise which resolves with the status of the payment.
 
 `requestPayment(imdbId)`
 \
-Request a payment by movie's imdb ID. Example: `tt8367814`.
+Request a payment by movie's imdb ID. Example: `tt8367814`. Returns a Promise which resolves with the status of the payment.
 
 `imdbToToken(imdbId)`
 \

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -95,7 +95,7 @@ class WhiteRabbitClient {
     await this.ensureIFrame(this.url(tokenId));
 
     return new Promise((resolve) => {
-      const messageHandler = (event) => {
+      const messageHandler = (event: MessageEvent) => {
         if (!event.data || !event.data.whiterabbit) return;
         const { whiterabbit } = event.data as WhiteRabbitMessage;
         this.closeIFrame();

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -98,7 +98,6 @@ class WhiteRabbitClient {
       const messageHandler = (event) => {
         if (!event.data || !event.data.whiterabbit) return;
         const { whiterabbit } = event.data as WhiteRabbitMessage;
-        console.log(whiterabbit);
         this.closeIFrame();
         window.removeEventListener('message', messageHandler);
         resolve({ status: whiterabbit.status });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -26,7 +26,7 @@ enum IdTypes {
   IMDB,
 };
 
-type WhiteRabbitMessage = MessageEvent & {
+type WhiteRabbitMessage = {
   whiterabbit: {
     status: boolean;
   }
@@ -94,7 +94,7 @@ class WhiteRabbitClient {
 
     await this.ensureIFrame(this.url(tokenId));
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const messageHandler = (event) => {
         if (!event.data || !event.data.whiterabbit) return;
         const { whiterabbit } = event.data as WhiteRabbitMessage;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -28,6 +28,7 @@ enum IdTypes {
 
 class WhiteRabbitClient {
   private iframe: any = null;
+  private closeHandle: any = null;
   private host: string;
 
   constructor(host: string = 'https://wr.leap.rocks') {
@@ -36,6 +37,15 @@ class WhiteRabbitClient {
 
   private url(tokenId: string) {
     return `${this.host}/movie/${tokenId}`;
+  }
+
+  private ensureCloseHandle() {
+    if (this.closeHandle) return this.closeHandle;
+    this.closeHandle = document.createElement('div');
+    this.closeHandle.appendChild(document.createTextNode('×'));
+    this.closeHandle.style.cssText = closeHandleCss;
+    this.closeHandle.addEventListener('click', () => this.closeIFrame());
+    return this.closeHandle;
   }
 
   private ensureIFrame(url: string) {
@@ -57,18 +67,17 @@ class WhiteRabbitClient {
         document.body.removeChild(loader);
         resolve();
       });
-      const closeHandle = document.createElement('div');
-      closeHandle.appendChild(document.createTextNode('×'));
-      closeHandle.style.cssText = closeHandleCss;
-      closeHandle.addEventListener('click', () => {
-        document.body.removeChild(this.iframe);
-        document.body.removeChild(closeHandle);
-        this.iframe = null;
-      });
+      const closeHandle = this.ensureCloseHandle();
       
       document.body.appendChild(this.iframe);
       document.body.appendChild(closeHandle);
     });
+  }
+
+  closeIFrame() {
+    document.body.removeChild(this.iframe);
+    document.body.removeChild(this.closeHandle);
+    this.iframe = null;
   }
 
   requestPayment(imdbOrTokenId: string) {

--- a/packages/streaming-site-example/app.tsx
+++ b/packages/streaming-site-example/app.tsx
@@ -4,10 +4,25 @@ import WhiteRabbitClient from '@whiterabbitjs/client';
 
 const client = new WhiteRabbitClient(process.env.WR_WALLET_HOST);
 
+type WhiteRabbitMessage = MessageEvent & {
+  whiterabbit: {
+    status: boolean;
+  }
+};
+
 const StreamingApp = () => {
 
   const openWhiteRabbit = () => {
     client.requestPayment('2142160385');
+
+    window.addEventListener('message', (event) => {
+      if (!event.data || !event.data.whiterabbit) return;
+      const { whiterabbit } = event.data;
+      console.log(whiterabbit);
+      if (!whiterabbit.status) {
+        client.closeIFrame();
+      }
+    });
   };
 
   return (

--- a/packages/streaming-site-example/app.tsx
+++ b/packages/streaming-site-example/app.tsx
@@ -1,33 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import WhiteRabbitClient from '@whiterabbitjs/client';
 
 const client = new WhiteRabbitClient(process.env.WR_WALLET_HOST);
 
-type WhiteRabbitMessage = MessageEvent & {
-  whiterabbit: {
-    status: boolean;
-  }
-};
-
 const StreamingApp = () => {
+  const [paymentStatus, setPaymentStatus] = useState();
 
   const openWhiteRabbit = () => {
-    client.requestPayment('2142160385');
-
-    window.addEventListener('message', (event) => {
-      if (!event.data || !event.data.whiterabbit) return;
-      const { whiterabbit } = event.data;
-      console.log(whiterabbit);
-      if (!whiterabbit.status) {
-        client.closeIFrame();
-      }
+    client.requestPayment('2142160385').then(({ status }: { status: boolean }) => {
+      setPaymentStatus(status);
     });
   };
 
   return (
     <div>
       <button onClick={openWhiteRabbit}>Knock-knock</button>
+      {paymentStatus !== undefined &&
+        <div>Payment: {paymentStatus ? 'success' : 'declined'}</div>
+      }
     </div>
   );
 }


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/leapdao/meta/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

- `requestPayment` returns a Promise of `{ status: boolean }`. `status` is set if the payment succeed, otherwise false (e.g. if the payment declined)
- client communicates with the burner app in iframe by listening to `message` event. Burner app uses `postMessage` to communicate back

<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
Closes #8